### PR TITLE
Fix for non-working options

### DIFF
--- a/cli/src/fetchIntercept.js
+++ b/cli/src/fetchIntercept.js
@@ -1,7 +1,9 @@
 if(new URL(e.url).pathname.endsWith('/account')) {
   return {
     ...JSON.parse(t),
-    subscription: 'pro',
+    subscription: {
+      type: 'pro'
+    },
     username: '🔓WeMod Pro Unlocker',
     profileImage: 'static/shared/images/default-profile-image.svg',
     ...{


### PR DESCRIPTION
This should fix #11 as they check for typeof subscription model.
![NVIDIA_Share_CsPLUCnUlm](https://user-images.githubusercontent.com/14022201/209026169-26f059f3-d1fc-4dea-a26d-07709745f0db.png)

I have added a pseudo model which is working for me.