### PR TITLE
Update patch to version 8.3.17

### DIFF
--- a/cli/src/fetchIntercept.js
+++ b/cli/src/fetchIntercept.js
@@ -1,13 +1,17 @@
-if(new URL(e.url).pathname.endsWith('/account')) {
-  return {
-    ...JSON.parse(t),
-    subscription: {
-      type: 'pro'
-    },
-    username: '🔓WeMod Pro Unlocker',
-    profileImage: 'static/shared/images/default-profile-image.svg',
-    ...{
-       /*{%account%}*/
+if ("application/json" === e.headers.get("Content-Type")) {
+  if (new URL(e.url).pathname.endsWith('/account')) {
+    var originalData = await e.json();
+    return {
+      ...originalData,
+      subscription: {
+        type: 'pro'
+      },
+      ...{
+        /*{%account%}*/
+        username: '🔓WeMod Pro Unlocker'
+      }
     }
   }
+  return e.json()
 }
+return e.text()


### PR DESCRIPTION
Bundle hashes will most likely change in next build so this is for current version only. The more stable solution would be to look for correct app bundle by `"application/json"===e.headers.get("Content-Type")` to patch it dynamically and then use any vendor bundle to remove banners but they could change that `Content-Type` check yet again so not sure it's worth the effort.